### PR TITLE
Add VIVO Cornell connector.

### DIFF
--- a/datasources/src/main/java/org/wheatinitiative/vivo/datasource/LaunchIngest.java
+++ b/datasources/src/main/java/org/wheatinitiative/vivo/datasource/LaunchIngest.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wheatinitiative.vivo.datasource.connector.cornell.Cornell;
 import org.wheatinitiative.vivo.datasource.connector.orcid.OrcidConnector;
 import org.wheatinitiative.vivo.datasource.connector.prodinra.Prodinra;
 import org.wheatinitiative.vivo.datasource.connector.rcuk.Rcuk;
@@ -59,7 +60,12 @@ public class LaunchIngest {
     
     private static DataSource getConnector(String connectorName) {
         DataSource connector = null;
-        if("rcuk".equals(connectorName)) {
+        if ("cornell".equals(connectorName)) {
+        	connector = new Cornell();
+        	connector.getConfiguration().setServiceURI(
+        			"http://vivo.cornell.edu");
+        }
+        else if ("rcuk".equals(connectorName)) {
             connector = new Rcuk();
             connector.getConfiguration().setServiceURI(
                     "http://http://gtr.rcuk.ac.uk/gtr/api/");

--- a/datasources/src/main/java/org/wheatinitiative/vivo/datasource/LaunchIngest.java
+++ b/datasources/src/main/java/org/wheatinitiative/vivo/datasource/LaunchIngest.java
@@ -25,7 +25,7 @@ public class LaunchIngest {
     public static void main(String[] args) {
         if(args.length < 3) {
             System.out.println("Usage: LaunchIngest " 
-                    + "rcuk|prodinra|usda|wheatinitiative outputfile " 
+                    + "rcuk|prodinra|usda|wheatinitiative|cornell outputfile " 
                     + "queryTerm ... [queryTermN] [limit]");
             return;
         } 
@@ -63,7 +63,7 @@ public class LaunchIngest {
         if ("cornell".equals(connectorName)) {
         	connector = new Cornell();
         	connector.getConfiguration().setServiceURI(
-        			"http://vivo.cornell.edu");
+        			"http://vivo.cornell.edu/");
         }
         else if ("rcuk".equals(connectorName)) {
             connector = new Rcuk();

--- a/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/VivoDataSource.java
+++ b/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/VivoDataSource.java
@@ -120,7 +120,7 @@ public class VivoDataSource extends ConnectorDataSource {
                     log.info("Fetching related resource " + r.getURI());
                     tmp.read(r.getURI());
                 } catch (Exception e) {
-                    log.error("Error retreiving " + r.getURI());
+                    log.error("Error retrieving " + r.getURI(), e);
                 }
             }
             Thread.sleep(MIN_REST);

--- a/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/cornell/Cornell.java
+++ b/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/cornell/Cornell.java
@@ -1,0 +1,55 @@
+package org.wheatinitiative.vivo.datasource.connector.cornell;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wheatinitiative.vivo.datasource.DataSource;
+import org.wheatinitiative.vivo.datasource.connector.VivoDataSource;
+import org.wheatinitiative.vivo.datasource.connector.prodinra.Prodinra;
+
+import com.hp.hpl.jena.rdf.model.Model;
+
+public class Cornell extends VivoDataSource implements DataSource {
+
+    private static final String CORNELL_VIVO_URL = "http://vivo.cornell.edu";
+    
+    private static final String CORNELL_TBOX_NS = "http://cornell.vivo.wheatinitiative.org/";
+    private static final String CORNELL_ABOX_NS = CORNELL_TBOX_NS + "individual/";
+    private static final String NAMESPACE_ETC = CORNELL_ABOX_NS + "n";
+    private static final String SPARQL_RESOURCE_DIR = "/cornell/sparql/";
+    
+
+    public static final Log log = LogFactory.getLog(Prodinra.class);
+    
+   
+    @Override 
+    protected String getRemoteVivoURL() {
+        return CORNELL_VIVO_URL;
+    }
+    
+    
+    protected Model constructForVIVO(Model model) {
+    	List<String> queries =  Arrays.asList("100-acti-organizations.sparql");
+    
+    	for(String query : queries) {
+    		log.debug("Executing query " + query);
+    		log.debug("Pre-query model size: " + model.size());
+    		construct(SPARQL_RESOURCE_DIR + query, model, NAMESPACE_ETC);
+    		log.debug("Post-query model size: " + model.size());
+    	}
+         
+         return model;
+ 	}
+    
+    
+    @Override
+    protected Model mapToVIVO(Model model) {
+
+    	model = constructForVIVO(model);
+
+    	return model;
+    }
+    
+}

--- a/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/cornell/Cornell.java
+++ b/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/cornell/Cornell.java
@@ -31,6 +31,9 @@ public class Cornell extends VivoDataSource implements DataSource {
     }
     
     
+    /**
+     * Transform the Cornell extention's RDF into VIVO RDF.
+     */
     protected Model constructForVIVO(Model model) {
     	List<String> queries =  Arrays.asList("100-acti-organizations.sparql");
     	

--- a/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/cornell/Cornell.java
+++ b/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/cornell/Cornell.java
@@ -7,23 +7,24 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wheatinitiative.vivo.datasource.DataSource;
 import org.wheatinitiative.vivo.datasource.connector.VivoDataSource;
-import org.wheatinitiative.vivo.datasource.connector.prodinra.Prodinra;
 
 import com.hp.hpl.jena.rdf.model.Model;
 
-public class Cornell extends VivoDataSource implements DataSource {
 
+
+public class Cornell extends VivoDataSource implements DataSource {
+	
     private static final String CORNELL_VIVO_URL = "http://vivo.cornell.edu";
     
-    private static final String CORNELL_TBOX_NS = "http://cornell.vivo.wheatinitiative.org/";
+    private static final String CORNELL_TBOX_NS = "http://vivo.cornell.edu/";
     private static final String CORNELL_ABOX_NS = CORNELL_TBOX_NS + "individual/";
     private static final String NAMESPACE_ETC = CORNELL_ABOX_NS + "n";
     private static final String SPARQL_RESOURCE_DIR = "/cornell/sparql/";
     
-
-    public static final Log log = LogFactory.getLog(Prodinra.class);
     
-   
+    public static final Log log = LogFactory.getLog(Cornell.class);
+    
+    
     @Override 
     protected String getRemoteVivoURL() {
         return CORNELL_VIVO_URL;
@@ -32,23 +33,23 @@ public class Cornell extends VivoDataSource implements DataSource {
     
     protected Model constructForVIVO(Model model) {
     	List<String> queries =  Arrays.asList("100-acti-organizations.sparql");
-    
+    	
     	for(String query : queries) {
     		log.debug("Executing query " + query);
     		log.debug("Pre-query model size: " + model.size());
     		construct(SPARQL_RESOURCE_DIR + query, model, NAMESPACE_ETC);
     		log.debug("Post-query model size: " + model.size());
     	}
-         
-         return model;
+    	
+        return model;
  	}
     
     
     @Override
     protected Model mapToVIVO(Model model) {
-
+    	
     	model = constructForVIVO(model);
-
+    	
     	return model;
     }
     

--- a/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/cornell/CornellService.java
+++ b/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/cornell/CornellService.java
@@ -1,0 +1,24 @@
+package org.wheatinitiative.vivo.datasource.connector.cornell;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.wheatinitiative.vivo.datasource.DataSource;
+import org.wheatinitiative.vivo.datasource.service.DataSourceService;
+
+public class CornellService extends DataSourceService {
+
+    private static volatile DataSource dataSource = null;
+    
+    @Override
+    protected DataSource getDataSource(HttpServletRequest request) {
+        return getDataSourceInstance();
+    }
+    
+    public static synchronized DataSource getDataSourceInstance() {
+        if(dataSource == null) {
+            dataSource = new Cornell();
+        }
+        return dataSource;
+    }
+    
+}

--- a/datasources/src/main/resources/cornell/sparql/100-acti-organizations.sparql
+++ b/datasources/src/main/resources/cornell/sparql/100-acti-organizations.sparql
@@ -1,0 +1,27 @@
+PREFIX acti:	<http://vivoweb.org/ontology/activity-insight#>
+PREFIX obo:		<http://purl.obolibrary.org/obo/>
+PREFIX foaf:	<http://xmlns.com/foaf/0.1/>
+PREFIX rdfs:	<http://www.w3.org/2000/01/rdf-schema#>
+
+
+
+CONSTRUCT {
+	
+	_:org a foaf:Organization .
+	_:org rdfs:label ?title .
+	
+	_:org obo:RO_0000053 _:role .
+	# An organazation has (_53) a role
+	
+	_:role a obo:ERO_0000224 .
+	# That role is a _224 (funding) role
+	
+	_:role obo:BFO_0000054 ?proj .
+	# This role gets realised (_54) in the project
+	
+} WHERE {
+	
+	?proj a acti:ImpactProject .
+	?proj acti:otherFedResearchFunding ?title .
+}
+

--- a/datasources/src/main/resources/cornell/sparql/100-acti-organizations.sparql
+++ b/datasources/src/main/resources/cornell/sparql/100-acti-organizations.sparql
@@ -21,7 +21,6 @@ CONSTRUCT {
 	
 } WHERE {
 	
-	?proj a acti:ImpactProject .
-	?proj acti:otherFedResearchFunding ?title .
+	?project a acti:ImpactProject .
+	?project acti:otherFedResearchFunding ?title .
 }
-


### PR DESCRIPTION
The VIVO Cornell connector is responsible for retrieving Cornell's data related to the given query terms.
Cornell has many extentions. Additional effort has to be made in order to map the most valuable data.

VIVO Cornell website:
http://vivo.cornell.edu/