### PR TITLE
VIVO Upenn connector.

### DIFF
--- a/datasources/pom.xml
+++ b/datasources/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.2.5</version>
+      <version>4.2.6</version>
       <scope>compile</scope>
     </dependency>
 

--- a/datasources/src/main/java/org/wheatinitiative/vivo/datasource/LaunchIngest.java
+++ b/datasources/src/main/java/org/wheatinitiative/vivo/datasource/LaunchIngest.java
@@ -12,6 +12,7 @@ import org.apache.commons.logging.LogFactory;
 import org.wheatinitiative.vivo.datasource.connector.orcid.OrcidConnector;
 import org.wheatinitiative.vivo.datasource.connector.prodinra.Prodinra;
 import org.wheatinitiative.vivo.datasource.connector.rcuk.Rcuk;
+import org.wheatinitiative.vivo.datasource.connector.upenn.Upenn;
 import org.wheatinitiative.vivo.datasource.connector.usda.Usda;
 import org.wheatinitiative.vivo.datasource.connector.wheatinitiative.WheatInitiative;
 
@@ -24,7 +25,7 @@ public class LaunchIngest {
     public static void main(String[] args) {
         if(args.length < 3) {
             System.out.println("Usage: LaunchIngest " 
-                    + "rcuk|prodinra|usda|wheatinitiative outputfile " 
+                    + "rcuk|prodinra|usda|wheatinitiative|upenn outputfile " 
                     + "queryTerm ... [queryTermN] [limit]");
             return;
         } 
@@ -62,7 +63,7 @@ public class LaunchIngest {
         if("rcuk".equals(connectorName)) {
             connector = new Rcuk();
             connector.getConfiguration().setServiceURI(
-                    "http://http://gtr.rcuk.ac.uk/gtr/api/");
+                    "http://gtr.rcuk.ac.uk/gtr/api/");
         } else if ("prodinra".equals(connectorName)) {
             connector = new Prodinra();
             connector.getConfiguration().setServiceURI(
@@ -77,6 +78,10 @@ public class LaunchIngest {
                     "http://www.wheatinitiative.org/administration/users/csv");
         } else if ("orcid".equals(connectorName)) {
             connector = new OrcidConnector();
+        } else if ("upenn".equals(connectorName)) {
+        	connector = new Upenn();
+        	connector.getConfiguration().setServiceURI(
+                    "http://vivo.upenn.edu/vivo/");
         } else {
             throw new RuntimeException("Connector not found: " 
                     + connectorName);

--- a/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/upenn/Upenn.java
+++ b/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/upenn/Upenn.java
@@ -8,8 +8,8 @@ import com.hp.hpl.jena.rdf.model.Model;
 
 
 /**
- * Currently there is an issue with the Certificate Authority that Upenn uses.
- * It seems that "InCommon RSA Server CA" requires the use of an intermediate certificate,
+ * Please note that the "InCommon Certificate Service" that VIVO Upenn is using,
+ * requires that an intermediate certificate is installed in the client's machine,
  * in order for the authentication process to be successful.
  */
 public class Upenn extends VivoDataSource implements DataSource {

--- a/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/upenn/Upenn.java
+++ b/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/upenn/Upenn.java
@@ -6,6 +6,7 @@ import org.wheatinitiative.vivo.datasource.connector.VivoDataSource;
 import com.hp.hpl.jena.rdf.model.Model;
 
 
+
 /**
  * Currently there is an issue with the Certificate Authority that Upenn uses.
  * It seems that "InCommon RSA Server CA" requires the use of an intermediate certificate,
@@ -15,10 +16,12 @@ public class Upenn extends VivoDataSource implements DataSource {
 
     private static final String UPENN_VIVO_URL = "http://vivo.upenn.edu/vivo";
     
+    
     @Override 
     protected String getRemoteVivoURL() {
         return UPENN_VIVO_URL;
     }
+    
     
     @Override
     protected Model mapToVIVO(Model model) {

--- a/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/upenn/Upenn.java
+++ b/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/upenn/Upenn.java
@@ -22,7 +22,8 @@ public class Upenn extends VivoDataSource implements DataSource {
     
     @Override
     protected Model mapToVIVO(Model model) {
-        return model;
+    	// UPENN VIVO is still using ontology version 1.5
+        return updateToOneSix(model);
     }
     
 }

--- a/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/upenn/Upenn.java
+++ b/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/upenn/Upenn.java
@@ -1,0 +1,28 @@
+package org.wheatinitiative.vivo.datasource.connector.upenn;
+
+import org.wheatinitiative.vivo.datasource.DataSource;
+import org.wheatinitiative.vivo.datasource.connector.VivoDataSource;
+
+import com.hp.hpl.jena.rdf.model.Model;
+
+
+/**
+ * Currently there is an issue with the Certificate Authority that Upenn uses.
+ * It seems that "InCommon RSA Server CA" requires the use of an intermediate certificate,
+ * in order for the authentication process to be successful.
+ */
+public class Upenn extends VivoDataSource implements DataSource {
+
+    private static final String UPENN_VIVO_URL = "http://vivo.upenn.edu/vivo";
+    
+    @Override 
+    protected String getRemoteVivoURL() {
+        return UPENN_VIVO_URL;
+    }
+    
+    @Override
+    protected Model mapToVIVO(Model model) {
+        return model;
+    }
+    
+}

--- a/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/upenn/UpennService.java
+++ b/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/upenn/UpennService.java
@@ -5,14 +5,18 @@ import javax.servlet.http.HttpServletRequest;
 import org.wheatinitiative.vivo.datasource.DataSource;
 import org.wheatinitiative.vivo.datasource.service.DataSourceService;
 
+
+
 public class UpennService extends DataSourceService {
 
 	private static volatile DataSource dataSource = null;
     
+	
     @Override
     protected DataSource getDataSource(HttpServletRequest request) {
         return getDataSourceInstance();
     }
+    
     
     public static synchronized DataSource getDataSourceInstance() {
         if(dataSource == null) {

--- a/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/upenn/UpennService.java
+++ b/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/upenn/UpennService.java
@@ -1,0 +1,24 @@
+package org.wheatinitiative.vivo.datasource.connector.upenn;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.wheatinitiative.vivo.datasource.DataSource;
+import org.wheatinitiative.vivo.datasource.service.DataSourceService;
+
+public class UpennService extends DataSourceService {
+
+	private static volatile DataSource dataSource = null;
+    
+    @Override
+    protected DataSource getDataSource(HttpServletRequest request) {
+        return getDataSourceInstance();
+    }
+    
+    public static synchronized DataSource getDataSourceInstance() {
+        if(dataSource == null) {
+            dataSource = new Upenn();
+        }
+        return dataSource;
+    }
+    
+}


### PR DESCRIPTION
The VIVO Upenn connector is responsible for retrieving Upenn's data related to the given query terms.

VIVO Upenn website:
https://vivo.upenn.edu/vivo/

Please note that the "InCommon Certificate Service" that Upenn is using, requires that an intermediate certificate is installed in the client's machine, in order for the authentication process to be successful.