### PR TITLE
Add VIVO Florida connector.

### DIFF
--- a/datasources/pom.xml
+++ b/datasources/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.2.5</version>
+      <version>4.2.6</version>
       <scope>compile</scope>
     </dependency>
 

--- a/datasources/src/main/java/org/wheatinitiative/vivo/datasource/LaunchIngest.java
+++ b/datasources/src/main/java/org/wheatinitiative/vivo/datasource/LaunchIngest.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wheatinitiative.vivo.datasource.connector.florida.Florida;
 import org.wheatinitiative.vivo.datasource.connector.orcid.OrcidConnector;
 import org.wheatinitiative.vivo.datasource.connector.prodinra.Prodinra;
 import org.wheatinitiative.vivo.datasource.connector.rcuk.Rcuk;
@@ -24,7 +25,7 @@ public class LaunchIngest {
     public static void main(String[] args) {
         if(args.length < 3) {
             System.out.println("Usage: LaunchIngest " 
-                    + "rcuk|prodinra|usda|wheatinitiative outputfile " 
+                    + "rcuk|prodinra|usda|wheatinitiative|florida outputfile " 
                     + "queryTerm ... [queryTermN] [limit]");
             return;
         } 
@@ -75,6 +76,10 @@ public class LaunchIngest {
             connector = new WheatInitiative();
             connector.getConfiguration().setServiceURI(
                     "http://www.wheatinitiative.org/administration/users/csv");
+        } else if ("florida".equals(connectorName)) {
+                connector = new Florida();
+                connector.getConfiguration().setServiceURI(
+                        "http://vivo.ufl.edu/");
         } else if ("orcid".equals(connectorName)) {
             connector = new OrcidConnector();
         } else {

--- a/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/florida/Florida.java
+++ b/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/florida/Florida.java
@@ -1,0 +1,22 @@
+package org.wheatinitiative.vivo.datasource.connector.florida;
+
+import org.wheatinitiative.vivo.datasource.DataSource;
+import org.wheatinitiative.vivo.datasource.connector.VivoDataSource;
+
+import com.hp.hpl.jena.rdf.model.Model;
+
+public class Florida extends VivoDataSource implements DataSource {
+	
+    private static final String FLORIDA_VIVO_URL = "http://vivo.ufl.edu";
+    
+    @Override 
+    protected String getRemoteVivoURL() {
+        return FLORIDA_VIVO_URL;
+    }
+    
+    @Override
+    protected Model mapToVIVO(Model model) {
+        return model;
+    }
+    
+}

--- a/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/florida/Florida.java
+++ b/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/florida/Florida.java
@@ -5,17 +5,27 @@ import org.wheatinitiative.vivo.datasource.connector.VivoDataSource;
 
 import com.hp.hpl.jena.rdf.model.Model;
 
+
+
+/**
+ * Please note that the "InCommon Certificate Service" that VIVO Florida is using,
+ * requires that an intermediate certificate is installed in the client's machine,
+ * in order for the authentication process to be successful.
+ */
 public class Florida extends VivoDataSource implements DataSource {
 	
     private static final String FLORIDA_VIVO_URL = "http://vivo.ufl.edu";
+    
     
     @Override 
     protected String getRemoteVivoURL() {
         return FLORIDA_VIVO_URL;
     }
     
+    
     @Override
     protected Model mapToVIVO(Model model) {
+    	
         return model;
     }
     

--- a/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/florida/FloridaService.java
+++ b/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/florida/FloridaService.java
@@ -1,0 +1,24 @@
+package org.wheatinitiative.vivo.datasource.connector.florida;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.wheatinitiative.vivo.datasource.DataSource;
+import org.wheatinitiative.vivo.datasource.service.DataSourceService;
+
+public class FloridaService extends DataSourceService {
+	
+    private static volatile DataSource dataSource = null;
+    
+    @Override
+    protected DataSource getDataSource(HttpServletRequest request) {
+        return getDataSourceInstance();
+    }
+    
+    public static synchronized DataSource getDataSourceInstance() {
+        if(dataSource == null) {
+            dataSource = new Florida();
+        }
+        return dataSource;
+    }
+    
+}

--- a/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/florida/FloridaService.java
+++ b/datasources/src/main/java/org/wheatinitiative/vivo/datasource/connector/florida/FloridaService.java
@@ -5,14 +5,18 @@ import javax.servlet.http.HttpServletRequest;
 import org.wheatinitiative.vivo.datasource.DataSource;
 import org.wheatinitiative.vivo.datasource.service.DataSourceService;
 
+
+
 public class FloridaService extends DataSourceService {
 	
     private static volatile DataSource dataSource = null;
+    
     
     @Override
     protected DataSource getDataSource(HttpServletRequest request) {
         return getDataSourceInstance();
     }
+    
     
     public static synchronized DataSource getDataSourceInstance() {
         if(dataSource == null) {


### PR DESCRIPTION
The VIVO Florida connector is responsible for retrieving University of Florida's data related to the given query terms.

VIVO Florida website:
https://vivo.ufl.edu/

Please note that the "InCommon Certificate Service" that Florida is using, requires that an intermediate certificate is installed in the client's machine, in order for the authentication process to be successful.